### PR TITLE
Deobfuscate with verification hash

### DIFF
--- a/client/worker.go
+++ b/client/worker.go
@@ -219,10 +219,6 @@ func (w *CrumblWorker) extract(user signer.Signer, isOwner bool, returnResult bo
 			err = e
 			return
 		}
-		hashedRes, _ := crypto.Hash([]byte(res), crypto.DEFAULT_HASH_ENGINE)
-		if w.VerificationHash != "" && utils.ToHex(hashedRes) != w.VerificationHash {
-			logWarning("verification hash is not coherent with uncrumbled data'")
-		}
 		if returnResult {
 			result = res
 			return
@@ -234,8 +230,8 @@ func (w *CrumblWorker) extract(user signer.Signer, isOwner bool, returnResult bo
 		err = e
 		return
 	}
-	if w.VerificationHash != "" && !strings.HasPrefix(res, w.VerificationHash) {
-		logWarning("verification hash is not coherent with uncrumbled data'")
+	if returnResult {
+		result = res
 	}
 	return
 }

--- a/core/uncrumbl.go
+++ b/core/uncrumbl.go
@@ -150,7 +150,7 @@ func (u *Uncrumbl) doUncrumbl() (uncrumbled []byte, err error) {
 			Key:    obfuscator.DEFAULT_KEY_STRING,
 			Rounds: obfuscator.DEFAULT_ROUNDS,
 		}
-		deobfuscated, e := obfuscator.Unapply(obfuscated)
+		deobfuscated, e := obfuscator.Unapply(obfuscated, verificationHash)
 		if e != nil {
 			err = e
 			return

--- a/obfuscator/obfuscator_test.go
+++ b/obfuscator/obfuscator_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/edgewhere/crumbl-exe/crypto"
 	"github.com/edgewhere/crumbl-exe/obfuscator"
 	"github.com/edgewhere/crumbl-exe/utils"
 
@@ -24,15 +25,17 @@ func TestObfuscatorApply(t *testing.T) {
 
 // TestObfuscatorUnapply ...
 func TestObfuscatorUnapply(t *testing.T) {
+	ref := "Edgewhere"
+	verificationHash, _ := crypto.Hash([]byte(ref), crypto.DEFAULT_HASH_ENGINE)
 	obfuscated, _ := utils.FromHex("3d7c0a0f51415a521054")
 	deobfuscated, err := obfuscator.Obfuscator{
 		Key:    obfuscator.DEFAULT_KEY_STRING,
 		Rounds: obfuscator.DEFAULT_ROUNDS,
-	}.Unapply(obfuscated)
+	}.Unapply(obfuscated, utils.ToHex(verificationHash))
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert.Equal(t, deobfuscated, "Edgewhere")
+	assert.Equal(t, deobfuscated, ref)
 }
 
 // TestAdd ...

--- a/slicer/slicer.go
+++ b/slicer/slicer.go
@@ -106,8 +106,8 @@ type mask struct {
 func (s *Slicer) buildSplitMask(dataLength int, seed Seed) (masks []mask, err error) {
 	dl := float64(dataLength)
 	nos := float64(s.NumberOfSlices)
-	dm := float64(s.DeltaMax)
 	averageSliceLength := math.Floor(dl / nos)
+	dm := math.Min(float64(s.DeltaMax), averageSliceLength-1) // used delta max cannot be higher than average size - 1
 	catchUp := dl - averageSliceLength*nos
 
 	length := 0.0


### PR DESCRIPTION
Before finding something more elegant: it fixes the problem when the obfuscation process adds a byte `[2]` in code, blurring the unpad process.