### PR TITLE
new padder

### DIFF
--- a/core/uncrumbl.go
+++ b/core/uncrumbl.go
@@ -150,7 +150,7 @@ func (u *Uncrumbl) doUncrumbl() (uncrumbled []byte, err error) {
 			Key:    obfuscator.DEFAULT_KEY_STRING,
 			Rounds: obfuscator.DEFAULT_ROUNDS,
 		}
-		deobfuscated, e := obfuscator.Unapply(obfuscated, verificationHash)
+		deobfuscated, e := obfuscator.Unapply(obfuscated)
 		if e != nil {
 			err = e
 			return
@@ -158,7 +158,8 @@ func (u *Uncrumbl) doUncrumbl() (uncrumbled []byte, err error) {
 
 		// 6a- Check
 		if !collector.Check([]byte(deobfuscated)) {
-			fmt.Fprintln(os.Stderr, "WARNING - source has not checked verification hash") // TODO Change it as an error?
+			err = errors.New("source has not checked verification hash")
+			return
 		}
 
 		// 7a- Return uncrumbled data, ie. original source normally

--- a/decrypter/collector.go
+++ b/decrypter/collector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/edgewhere/crumbl-exe/crypto"
+	"github.com/edgewhere/crumbl-exe/padder"
 	"github.com/edgewhere/crumbl-exe/utils"
 )
 
@@ -37,7 +38,12 @@ func (c *Collector) ToObfuscated() (obfuscated []byte, err error) {
 			err = fmt.Errorf("missing slice with index: %d", i)
 			return
 		}
-		o += utils.Unpad(string(uncrumb.ToSlice()))
+		unpadded, _, e := padder.Unapply([]byte(uncrumb.ToSlice()))
+		if e != nil {
+			err = e
+			return
+		}
+		o += string(unpadded)
 	}
 	obfuscated = []byte(o)
 	return

--- a/obfuscator/obfuscator_test.go
+++ b/obfuscator/obfuscator_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/edgewhere/crumbl-exe/crypto"
 	"github.com/edgewhere/crumbl-exe/obfuscator"
 	"github.com/edgewhere/crumbl-exe/utils"
 
@@ -26,12 +25,11 @@ func TestObfuscatorApply(t *testing.T) {
 // TestObfuscatorUnapply ...
 func TestObfuscatorUnapply(t *testing.T) {
 	ref := "Edgewhere"
-	verificationHash, _ := crypto.Hash([]byte(ref), crypto.DEFAULT_HASH_ENGINE)
 	obfuscated, _ := utils.FromHex("3d7c0a0f51415a521054")
 	deobfuscated, err := obfuscator.Obfuscator{
 		Key:    obfuscator.DEFAULT_KEY_STRING,
 		Rounds: obfuscator.DEFAULT_ROUNDS,
-	}.Unapply(obfuscated, utils.ToHex(verificationHash))
+	}.Unapply(obfuscated)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/padder/padder.go
+++ b/padder/padder.go
@@ -1,0 +1,122 @@
+package padder
+
+import (
+	"errors"
+	"math"
+
+	"github.com/edgewhere/crumbl-exe/utils"
+)
+
+// The 'padder' module adds left padding to a passed byte array with Apply(), and reverse the operation with Unapply().
+//
+// If you simply want to left pad to make the length of a data even, pass the length of the data as second parameter
+// and `true` as third parameter to Apply(), eg. ```
+// 		padded, _, err := padder.Apply(data, len(data), true)
+// ```
+// Otherwise, pass the maximum length of all data as second parameter (normally greater than or equal to the length of the data)
+// and `false` as the third, eg. ```
+// 		padded, _, err := padder.Apply(data, maxSliceLength, false)
+// ```
+
+const (
+	// ALTERNATE_PADDING_CHARACTER_1 ...
+	ALTERNATE_PADDING_CHARACTER_1 rune = 4 // Unicode U+0004: end-of-transmission
+
+	// ALTERNATE_PADDING_CHARACTER_2 ...
+	ALTERNATE_PADDING_CHARACTER_2 rune = 5 // Unicode U+0005: enquiry
+
+	// PREPEND_SIZE is the minimum number of prepended padding character in the padded result
+	PREPEND_SIZE = 2
+)
+
+// Apply left pads the passed data (generally a slice) making it at least (PREPEND_SIZE + length) bytes long;
+// if the 'buildEven' parameter is set to `true`, it doesn't take PREPEND_SIZE into account and
+// only adds padding bytes to the left up to the passed length.
+func Apply(slice []byte, length int, buildEven bool) (padded []byte, padChar rune, err error) {
+	if len(slice) == 0 {
+		err = errors.New("empty slice")
+		return
+	}
+	if length < 1 {
+		err = errors.New("max slice length too short")
+		return
+	}
+	if buildEven && length != len(slice) && length%2 != 0 {
+		err = errors.New("wished length is not even")
+		return
+	}
+
+	// An already even slice doesn't need processing when buildEven is set to `true` and minimum length is reached
+	if buildEven && len(slice)%2 == 0 && len(slice) >= length {
+		padded = slice
+		return
+	}
+
+	// 1 - Choose padding character
+	firstByte := slice[0]
+	lastByte := slice[len(slice)-1]
+	var pc rune
+	if firstByte == byte(utils.LEFT_PADDING_CHARACTER) {
+		if lastByte == byte(ALTERNATE_PADDING_CHARACTER_1) {
+			pc = ALTERNATE_PADDING_CHARACTER_2
+		} else {
+			pc = ALTERNATE_PADDING_CHARACTER_1
+		}
+	} else {
+		if lastByte == byte(utils.LEFT_PADDING_CHARACTER) {
+			if firstByte == byte(ALTERNATE_PADDING_CHARACTER_1) {
+				pc = ALTERNATE_PADDING_CHARACTER_2
+			} else {
+				pc = ALTERNATE_PADDING_CHARACTER_1
+			}
+		} else {
+			pc = utils.LEFT_PADDING_CHARACTER
+		}
+	}
+
+	// 2 - Define filling delta
+	delta := int(math.Max(0, float64(length-len(slice))))
+	if buildEven {
+		if (len(slice)+delta)%2 != 0 {
+			delta++
+		}
+	} else {
+		delta += PREPEND_SIZE
+	}
+
+	// 3 - Do pad
+	var p []byte
+	for i := 0; i < delta; i++ {
+		p = append(p, byte(pc))
+	}
+	p = append(p, slice...)
+
+	return p, pc, nil
+}
+
+// Unapply removes the left padding from the passed padded data.
+func Unapply(padded []byte) (slice []byte, err error) {
+	if len(padded) < PREPEND_SIZE+1 {
+		err = errors.New("invalid padded data: data too short")
+		return
+	}
+
+	// 1 - Detect padding character
+	padChar := padded[0]
+	if padded[PREPEND_SIZE-1] != padChar {
+		err = errors.New("invalid padded data: wrong padding")
+		return
+	}
+
+	// 2 - Do unpad
+	unpadded := padded
+	for len(unpadded) > 0 && unpadded[0] == padChar {
+		unpadded = unpadded[1:]
+	}
+	if len(unpadded) == 0 {
+		err = errors.New("invalid padded data: all pad chars")
+		return
+	}
+
+	return unpadded, nil
+}

--- a/padder/padder_test.go
+++ b/padder/padder_test.go
@@ -73,17 +73,36 @@ func TestApply(t *testing.T) {
 // TestUnapply ...
 func TestUnapply(t *testing.T) {
 	padded1 := []byte{2, 2, 3, 4, 5}
-	unpadded1, err := padder.Unapply(padded1)
+	unpadded1, padChar, err := padder.Unapply(padded1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	assert.DeepEqual(t, unpadded1, []byte{3, 4, 5})
+	assert.Equal(t, padChar, utils.LEFT_PADDING_CHARACTER)
 
 	padded2 := []byte{2, 2, 2}
-	_, err = padder.Unapply(padded2)
+	_, _, err = padder.Unapply(padded2)
 	assert.Error(t, err, "invalid padded data: all pad chars")
 
 	padded3 := []byte{5, 5, 5, 2, 4}
-	unpadded3, _ := padder.Unapply(padded3)
+	unpadded3, padChar, _ := padder.Unapply(padded3)
 	assert.DeepEqual(t, unpadded3, []byte{2, 4})
+	assert.Equal(t, padChar, padder.ALTERNATE_PADDING_CHARACTER_2)
+
+	evenData := []byte{255, 255}
+	unpadded4, padChar, err := padder.Unapply(evenData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.DeepEqual(t, unpadded4, evenData)
+	assert.Equal(t, padChar, padder.NO_PADDING_CHARACTER) // rune zero value
+
+	evenZero := []byte{0, 0}
+	unpadded5, padChar, _ := padder.Unapply(evenZero)
+	assert.DeepEqual(t, unpadded5, evenZero)
+	assert.Equal(t, padChar, padder.NO_PADDING_CHARACTER) // doesn't mean that if has taken zero value as pad character
+
+	wrongPadded := []byte{255, 254, 253}
+	_, _, err = padder.Unapply(wrongPadded)
+	assert.Error(t, err, "invalid padded data: wrong padding")
 }

--- a/padder/padder_test.go
+++ b/padder/padder_test.go
@@ -1,0 +1,89 @@
+package padder_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/edgewhere/crumbl-exe/padder"
+	"github.com/edgewhere/crumbl-exe/utils"
+	"gotest.tools/assert"
+)
+
+// TestApply ...
+func TestApply(t *testing.T) {
+	maxSliceLength := 3
+	slice1 := []byte{3, 4, 5}
+	padded1, padChar, err := padder.Apply(slice1, maxSliceLength, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.DeepEqual(t, padded1, []byte{2, 2, 3, 4, 5})
+	assert.Equal(t, padChar, utils.LEFT_PADDING_CHARACTER)
+	assert.Equal(t, len(padded1), maxSliceLength+padder.PREPEND_SIZE)
+
+	slice2 := []byte{6, 7}
+	padded2, padChar, _ := padder.Apply(slice2, maxSliceLength, false)
+	assert.DeepEqual(t, padded2, []byte{2, 2, 2, 6, 7})
+	assert.Equal(t, padChar, utils.LEFT_PADDING_CHARACTER)
+	assert.Equal(t, len(padded2), maxSliceLength+padder.PREPEND_SIZE)
+
+	slice3 := []byte{2, 3}
+	padded3, padChar, _ := padder.Apply(slice3, maxSliceLength, false)
+	assert.DeepEqual(t, padded3, []byte{byte(padChar), byte(padChar), byte(padChar), 2, 3})
+	assert.Equal(t, byte(padChar), padded3[0])
+	assert.Equal(t, padChar, padder.ALTERNATE_PADDING_CHARACTER_1)
+	assert.Assert(t, string(padChar) != string(utils.LEFT_PADDING_CHARACTER))
+	assert.Equal(t, len(padded3), maxSliceLength+padder.PREPEND_SIZE)
+
+	slice4 := []byte{2, 4}
+	padded4, padChar, _ := padder.Apply(slice4, maxSliceLength, false)
+	assert.DeepEqual(t, padded4, []byte{byte(padChar), byte(padChar), byte(padChar), 2, 4})
+	assert.Equal(t, byte(padChar), padded4[0])
+	assert.Equal(t, padChar, padder.ALTERNATE_PADDING_CHARACTER_2)
+
+	expected := []byte{2, 1, 1, 1}
+	slice5 := []byte{1, 1, 1}
+	padded5, _, _ := padder.Apply(slice5, len(slice5), true)
+	assert.Equal(t, len(padded5), 4)
+	assert.DeepEqual(t, padded5, expected)
+
+	wrongSlice := []byte{}
+	_, _, err = padder.Apply(wrongSlice, maxSliceLength, false)
+	assert.Error(t, err, "empty slice")
+
+	wrongLength := 0
+	_, _, err = padder.Apply(slice1, wrongLength, false)
+	assert.Error(t, err, "max slice length too short")
+
+	alreadyEvenData := []byte{2, 2}
+	padded, _, _ := padder.Apply(alreadyEvenData, len(alreadyEvenData), true)
+	assert.DeepEqual(t, alreadyEvenData, padded)
+
+	alreadyEvenButTooShort := []byte{4, 4}
+	wishedLength := 4
+	padded, _, _ = padder.Apply(alreadyEvenButTooShort, wishedLength, true)
+	fmt.Println(padded)
+	assert.DeepEqual(t, padded, []byte{2, 2, 4, 4})
+	assert.Equal(t, len(padded), wishedLength)
+
+	_, _, err = padder.Apply(slice1, 5, true)
+	assert.Error(t, err, "wished length is not even")
+}
+
+// TestUnapply ...
+func TestUnapply(t *testing.T) {
+	padded1 := []byte{2, 2, 3, 4, 5}
+	unpadded1, err := padder.Unapply(padded1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.DeepEqual(t, unpadded1, []byte{3, 4, 5})
+
+	padded2 := []byte{2, 2, 2}
+	_, err = padder.Unapply(padded2)
+	assert.Error(t, err, "invalid padded data: all pad chars")
+
+	padded3 := []byte{5, 5, 5, 2, 4}
+	unpadded3, _ := padder.Unapply(padded3)
+	assert.DeepEqual(t, unpadded3, []byte{2, 4})
+}

--- a/slicer/slicer_test.go
+++ b/slicer/slicer_test.go
@@ -22,23 +22,24 @@ func TestSliceApply(t *testing.T) {
 		t.Fatal(err)
 	}
 	assert.Equal(t, len(slices1), s1.NumberOfSlices)
-	assert.Equal(t, slices1[0], slicer.Slice("11111"))
-	assert.Equal(t, slices1[1], slicer.Slice("22222"))
-	assert.Equal(t, slices1[2], slicer.Slice("33333"))
-	assert.Equal(t, slices1[3], slicer.Slice("44444"))
+	assert.Equal(t, slices1[0], slicer.Slice("11111"))
+	assert.Equal(t, slices1[1], slicer.Slice("22222"))
+	assert.Equal(t, slices1[2], slicer.Slice("33333"))
+	assert.Equal(t, slices1[3], slicer.Slice("44444"))
 
+	str2 := "111111111222222222333333333444444444"
 	s2 := slicer.Slicer{
 		NumberOfSlices: 4,
 		DeltaMax:       2,
 	}
-	slices2, err := s2.Apply("111111111222222222333333333444444444")
+	slices2, err := s2.Apply(str2)
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, s := range slices2 {
-		assert.Equal(t, len(s), 11)
+		assert.Equal(t, len(s), 13)
 	}
-	assert.Equal(t, slices2[3], slicer.Slice("4444444")) // It's predictive thanks to the seed
+	assert.Equal(t, slices2[3], slicer.Slice("4444444")) // It's predictive thanks to the seed
 }
 
 // TestSliceUnapply ...
@@ -49,10 +50,10 @@ func TestSliceUnapply(t *testing.T) {
 	}
 
 	data, err := s.Unapply([]slicer.Slice{
-		slicer.Slice("11111"),
-		slicer.Slice("22222"),
-		slicer.Slice("33333"),
-		slicer.Slice("44444"),
+		slicer.Slice("11111"),
+		slicer.Slice("22222"),
+		slicer.Slice("33333"),
+		slicer.Slice("44444"),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -88,14 +89,14 @@ func TestSeed(t *testing.T) {
 // TestSlicer should work under heavy load
 func TestSlicer(t *testing.T) {
 	for i := 1; i < 10000; i++ {
-		data := string(strconv.Itoa(rand.New(rand.NewSource(time.Now().UnixNano())).Intn(10) + i))
+		data := string(strconv.Itoa((rand.New(rand.NewSource(time.Now().UnixNano())).Intn(10)+1)*1e6 + i))
 		s := slicer.Slicer{
-			NumberOfSlices: 10,
-			DeltaMax:       slicer.GetDeltaMax(len(data), 10),
+			NumberOfSlices: 2,
+			DeltaMax:       slicer.GetDeltaMax(len(data), 2),
 		}
 		tmp, err := s.Apply(data)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatal(err, i, data, []byte(data), tmp)
 		}
 		found, err := s.Unapply(tmp)
 		if err != nil {

--- a/utils/padding.go
+++ b/utils/padding.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 )
 
+// Only kept for legacy compliance
+
 const (
 	// LEFT_PADDING_CHARACTER ...
 	LEFT_PADDING_CHARACTER rune = 2 // Unicode U+0002: start of text


### PR DESCRIPTION
In order to get rid of problems linked to the padding and xoring issues regularly found with a more elegant solution, I developed a new padder submodule.
I decided to manipulate bytes instead of strings for that purpose.
The new padder allows for the use of both padding with extra pad or just padding in case of data of odd length.
I left the padding utils for legacy but they shouldn't be used anymore as they are error-prone.
I also left the mandatory verification hash for the uncrumbling process, whereas it's not strictly needed anymore (I got rid of my ugly patch FWIW), but I think it's more secure that way.